### PR TITLE
allow customization of userCtx.name via localStorage

### DIFF
--- a/couchusercontextobject.js
+++ b/couchusercontextobject.js
@@ -21,7 +21,7 @@ module.exports = function buildUserContextObject(info) {
   //a default userCtx (admin party like)
   return {
     db: info.db_name,
-    name: null,
+    name: localStorage.getItem('pouch.userCtx.name'),
     roles: ["_admin"]
   };
 };


### PR DESCRIPTION
something like this change would enable applications to optionally allow users to set meaningful names for themselves (or their machines, we should say, or browsers), so apps can, for example, tag each document/modification with their name.

otherwise the name would be `null` anyway.
